### PR TITLE
fixed nhl_setup app 

### DIFF
--- a/src/nhl_setup/nhl_setup.py
+++ b/src/nhl_setup/nhl_setup.py
@@ -274,7 +274,7 @@ def main():
     team = None
     team = get_team(team_index,selected_teams,preferences_teams,qmark)
 
-    if len(selected_teams) > 0:
+    if len(selected_teams) > 0 and (team in selected_teams):
         selected_teams.remove(team)
 
     preferences_teams.append(team)
@@ -283,7 +283,7 @@ def main():
     while team_select:
         team_index += 1
         team = get_team(team_index,selected_teams,preferences_teams,qmark)
-        if team in selected_teams:
+        if len(selected_teams) > 0 and (team in selected_teams):
             selected_teams.remove(team)
         preferences_teams.append(team)
         team_select = select_teams(qmark)


### PR DESCRIPTION
When you select a team that's not one of the initial teams in the config.json.sample (or config.json), the app now doesn't throw an exception.

I have not been able to reproduce the configuration for dimmer and pushbutton being outside of the sbio branch