### PR TITLE
Fixes for nhl_setup and weather alerts

### DIFF
--- a/src/api/weather/ecAlerts.py
+++ b/src/api/weather/ecAlerts.py
@@ -53,7 +53,7 @@ class ecWxAlerts(object):
 
             if num_alerts > 0:
                 # Only get the latest alert
-                i = -1
+                i = 0
                 # Create the warnings, watches and advisory lists from curr_alerts but only take the most recent one
 
                 wx_num_endings = len(curr_alerts.get("endings").get("value","0"))

--- a/src/api/weather/ecAlerts.py
+++ b/src/api/weather/ecAlerts.py
@@ -39,7 +39,11 @@ class ecWxAlerts(object):
             # No alerts, the dictionary still comes back with empty values for 
             # warning, watch, advisory, statements and endings
             # Currently don't do anything with a statement
-            # debug.info(curr_alerts)
+            #debug.info(curr_alerts)
+
+            #Find the latest date in the curr_alerts
+
+
 
             len_warn = len(curr_alerts.get("warnings").get("value"))
             len_watch = len(curr_alerts.get("watches").get("value"))
@@ -58,10 +62,17 @@ class ecWxAlerts(object):
                 wx_num_advisory = len(curr_alerts.get("advisories").get("value","0"))
 
                 wx_total_alerts = wx_num_endings + wx_num_warning + wx_num_watch + wx_num_advisory
+                warn_datetime = 0
+                watch_datetime = 0
+                advisory_datetime = 0
+                warning = []
+                watch = []
+                advisory = []
+                alerts = []
                 
                 if wx_num_warning > 0:
                     warn_date = curr_alerts["warnings"]["value"][i]["date"]
-                     #Convert to date for display
+                    #Convert to date for display
                     warn_datetime = datetime.datetime.strptime(warn_date,self.alert_date_format)
                     if self.time_format == "%H:%M":
                         wx_alert_time = warn_datetime.strftime("%m/%d %H:%M")
@@ -69,8 +80,12 @@ class ecWxAlerts(object):
                         wx_alert_time = warn_datetime.strftime("%m/%d %I:%M %p")
                     #Strip out the Warning at end of string for the title
                     wx_alert_title = curr_alerts["warnings"]["value"][i]["title"][:-(len(" Warning"))]
-                    self.data.wx_alerts = [wx_alert_title,"warning",wx_alert_time]
-                elif wx_num_watch > 0:
+                    warning = [wx_alert_title,"warning",wx_alert_time]
+                    alerts.append(warning)
+                
+                
+
+                if wx_num_watch > 0:
                     watch_date = curr_alerts["watches"]["value"][i]["date"]
                     #Convert to date for display
                     watch_datetime = datetime.datetime.strptime(watch_date,self.alert_date_format)
@@ -79,8 +94,12 @@ class ecWxAlerts(object):
                     else:
                         wx_alert_time = watch_datetime.strftime("%m/%d %I:%M %p")
                     wx_alert_title = curr_alerts["watches"]["value"][i]["title"][:-(len(" Watch"))]
-                    self.data.wx_alerts = [wx_alert_title,"watch",wx_alert_time]
-                elif wx_num_advisory > 0:
+                    watch = [wx_alert_title,"watch",wx_alert_time]
+                    alerts.append(watch)
+
+                
+
+                if wx_num_advisory > 0:
                     advisory_date = curr_alerts["advisories"]["value"][i]["date"]
                     #Convert to date for display
                     advisory_datetime = datetime.datetime.strptime(advisory_date,self.alert_date_format)
@@ -91,8 +110,17 @@ class ecWxAlerts(object):
                         wx_alert_time = advisory_datetime.strftime("%m/%d %I:%M %p")
 
                     wx_alert_title = curr_alerts["advisories"]["value"][i]["title"][:-(len(" Advisory"))]
-                    self.data.wx_alerts = [wx_alert_title,"advisory",wx_alert_time]
-                elif wx_num_endings > 0:
+                    advisory = [wx_alert_title,"advisory",wx_alert_time]
+                    alerts.append(advisory)
+
+                
+                #Find the latest alert time to set what the alert should be shown
+                #debug.info(alerts)
+                alerts.sort(key = lambda x: x[2],reverse=True)
+                #debug.info(alerts)
+                self.data.wx_alerts = alerts[0]
+
+                if wx_num_endings > 0:
                     ending_date = curr_alerts["endings"]["value"][i]["date"]
                     #Convert to date for display
                     ending_datetime = datetime.datetime.strptime(ending_date,self.alert_date_format)
@@ -104,9 +132,9 @@ class ecWxAlerts(object):
                     self.data.wx_alerts = [curr_alerts["endings"]["value"][i]["title"],"ended",wx_alert_time]
                     self.data.wx_alert_interrupt = False
                     self.weather_alert = 0
-                else:
-                    self.data.wx_alert_interrupt = False
-                    self.weather_alert = 0
+                # else:
+                #     self.data.wx_alert_interrupt = False
+                #     self.weather_alert = 0
 
                 if len(self.data.wx_alerts) > 0:
                     debug.info(self.data.wx_alerts)

--- a/src/boards/wxAlert.py
+++ b/src/boards/wxAlert.py
@@ -17,6 +17,9 @@ class wxAlert:
         #Set the width, add 3 to allow for text to scroll completely off screen
         self.alert_width = alert_info["size"][0] + 3
 
+        if self.alert_width < self.pos:
+            self.alert_width = self.pos + 1
+
         self.scroll = self.data.config.weather_scroll_alert
         if not self.scroll:
             # Force to display the top and bottom titles on static display
@@ -47,7 +50,7 @@ class wxAlert:
             #self.matrix.draw.rectangle([60, 25, 64, 32], fill=(255,0,0)) # warning
             if self.data.wx_alerts[1] == "warning":
                 self.matrix.draw.rectangle([0, 0, self.matrix.width, 8], fill=(255,0,0)) # warning
-                self.matrix.draw.rectangle([0, self.matrix.height, self.matrix.width, self.matrix.height], fill=(255,0,0)) # warning
+                self.matrix.draw.rectangle([0, self.matrix.height - 8, self.matrix.width, self.matrix.height], fill=(255,0,0)) # warning
                 
                 if self.drawtitle:
                     if self.data.wx_alerts[0] == "Severe Thunderstorm":
@@ -100,7 +103,7 @@ class wxAlert:
                             self.layout4.title_bottom,
                             "Advisory"
                         )  
-            
+
             if self.scroll:
                 self.matrix.draw_text([self.pos,9],self.data.wx_alerts[0],self.wxfont,fill=(255,255,255))
                 

--- a/src/boards/wxWeather.py
+++ b/src/boards/wxWeather.py
@@ -204,7 +204,7 @@ class wxWeather:
             self.data.wx_alerts[0] = "Frzn Drzl"
 
         if self.data.wx_alerts[1] == "warning": 
-            self.matrix.draw.rectangle([0, 0, self.matrix.wodth, 8], fill=(255,0,0)) # warning
+            self.matrix.draw.rectangle([0, 0, self.matrix.width, 8], fill=(255,0,0)) # warning
 
             self.matrix.draw_text_layout(
                 self.layout4.warning,

--- a/src/nhl_setup/nhl_setup.py
+++ b/src/nhl_setup/nhl_setup.py
@@ -428,8 +428,9 @@ def main():
         team_index=0
         team = None
         team = get_team(team_index,selected_teams,preferences_teams,qmark)
+        preferences_teams.append(team)
         
-        default_config['preferences']['teams'] = team
+        default_config['preferences']['teams'] = preferences_teams
         
         if questionary.confirm("Save {}/config.json file?".format(args.confdir),qmark=qmarksave,style=custom_style_dope).ask():
             save_config(default_config,args.confdir)


### PR DESCRIPTION
FIx for nhl_setup (see [https://github.com/riffnshred/nhl-led-scoreboard/issues/102](url))
Fix for weather alerts that are shorter than the width of the panel (eg Heat) and scrolling would never work and the screen would stay blank.