### PR TITLE
Fix usage of Stanley Cup Champions

### DIFF
--- a/src/boards/stanley_cup_champions.py
+++ b/src/boards/stanley_cup_champions.py
@@ -4,9 +4,10 @@ import debug
 
 class StanleyCupChampions:
     def __init__(self, data, matrix, sleepEvent):
-        
+        print("Stanley cup champions id: {}".format(data.ScChampions_id))
         self.team_id = data.ScChampions_id
-        print(data.ScChampions_id)
+        if self.team_id is None:
+            return
         self.team_abbrev = data.teams_info[self.team_id].abbreviation
         self.data = data
         self.team_info = data.teams_info[self.team_id]
@@ -17,13 +18,13 @@ class StanleyCupChampions:
         self.sleepEvent.clear()
 
     def render(self):
-        print("Display stanleycup champions {} ".format(self.data.teams_info[self.team_id].abbreviation))
-        self.matrix.clear()
-        bg_img = Image.open(get_file('assets/images/stanleycupchamps_bg.png'))
-        self.matrix.draw_image((0,0), bg_img)
-
         # If there is a Stanley cup champion, show the board. Else, pass
         if self.team_id:
+            print("Display stanley cup champions {} ".format(self.data.teams_info[self.team_id].abbreviation))
+            self.matrix.clear()
+            bg_img = Image.open(get_file('assets/images/stanleycupchamps_bg.png'))
+            self.matrix.draw_image((0,0), bg_img)
+
             team_color_main = self.team_colors.color("{}.primary".format(self.team_id))
             team_color_accent = self.team_colors.color("{}.text".format(self.team_id))
 
@@ -31,7 +32,7 @@ class StanleyCupChampions:
             self.matrix.render()
             self.sleepEvent.wait(0.5)
             self.matrix.draw_text(
-                (18, 7), 
+                (18, 7),
                 self.team_abbrev,
                 font=self.font,
                 fill=(team_color_accent['r'], team_color_accent['g'], team_color_accent['b']),
@@ -41,24 +42,24 @@ class StanleyCupChampions:
             self.matrix.render()
             self.sleepEvent.wait(0.5)
             self.matrix.draw_text(
-                (37, 7), 
-                str(self.data.year), 
-                font=self.font, 
+                (37, 7),
+                str(self.data.year),
+                font=self.font,
                 fill=(0, 0, 0),
                 backgroundColor=(200,200,200)
             )
             self.matrix.render()
             self.sleepEvent.wait(0.5)
             self.matrix.draw_text(
-                (12, 14), 
-                "STANLEY CUP", 
-                font=self.font, 
+                (12, 14),
+                "STANLEY CUP",
+                font=self.font,
                 fill=(255,255,255),
             )
             self.matrix.render()
             self.sleepEvent.wait(0.5)
             self.matrix.draw_text(
-                (16, 21), 
+                (16, 21),
                 "CHAMPIONS",
                 font=self.font,
                 fill=(team_color_accent['r'], team_color_accent['g'], team_color_accent['b']),

--- a/src/renderer/main.py
+++ b/src/renderer/main.py
@@ -52,7 +52,7 @@ class MainRenderer:
 
         while True:
             debug.info('Rendering...')
-            
+
             if self.status.is_offseason(self.data.date()):
                 # Offseason (Show offseason related stuff)
                 debug.info("It's offseason")
@@ -74,10 +74,8 @@ class MainRenderer:
                 else:
                     debug.info("Game Day Wooooo")
                     self.__render_game_day()
-            
+
             self.data.refresh_data()
-
-
 
     def __render_offday(self):
         while True:
@@ -138,7 +136,7 @@ class MainRenderer:
                 self.data.screensaver_livegame = True
                 debug.info("Game is Live")
                 sbrenderer = ScoreboardRenderer(self.data, self.matrix, self.scoreboard)
-                
+
                 self.check_new_penalty()
                 self.check_new_goals()
                 self.__render_live(sbrenderer)
@@ -159,11 +157,11 @@ class MainRenderer:
                 debug.info("Game Over")
                 sbrenderer = ScoreboardRenderer(self.data, self.matrix, self.scoreboard)
                 self.check_new_goals()
-                if self.data.isPlayoff and self.stanleycup_round:
+                if self.data.isPlayoff and self.data.stanleycup_round:
                     self.check_stanley_cup_champion()
                     if self.data.ScChampions_id:
-                        StanleyCupChampions(self.data, self.data.ScChampions_id, self.matrix, self.sleepEvent).render()
-                
+                        StanleyCupChampions(self.data, self.matrix, self.sleepEvent).render()
+
                 self.__render_postgame(sbrenderer)
 
                 self.sleepEvent.wait(self.refresh_rate)
@@ -173,7 +171,7 @@ class MainRenderer:
                 debug.info("FINAL")
                 sbrenderer = ScoreboardRenderer(self.data, self.matrix, self.scoreboard)
                 self.check_new_goals()
-                if self.data.isPlayoff and self.stanleycup_round:
+                if self.data.isPlayoff and self.data.stanleycup_round:
                     self.check_stanley_cup_champion()
                     if self.data.ScChampions_id:
                         StanleyCupChampions(self.data, self.matrix, self.sleepEvent).render()
@@ -237,7 +235,7 @@ class MainRenderer:
         debug.info("Showing Irregular")
         self.matrix.clear()
         sbrenderer.render()
-    
+
 
     def check_new_goals(self):
         debug.log("Check new goal")
@@ -285,7 +283,7 @@ class MainRenderer:
                 return
             # run the goal animation
             self._draw_event_animation("goal", home_id, home_name)
-            
+
     def check_new_penalty(self):
         debug.log("Check new penalty")
 
@@ -401,4 +399,5 @@ class MainRenderer:
         self.matrix.graphics.DrawLine(self.matrix.matrix, (self.matrix.width * .5) - 9, self.matrix.height - 1, (self.matrix.width * .5) + 9, self.matrix.height - 1, color)
 
     def test_stanley_cup_champion(self, team_id):
-        StanleyCupChampions(self.data, team_id, self.matrix, self.sleepEvent).render()
+        self.data.ScChampions_id = team_id
+        StanleyCupChampions(self.data, self.matrix, self.sleepEvent).render()


### PR DESCRIPTION
Tested using command line argument to set a champion:
```
sudo python3 src/main.py --led-rows=32 --led-cols=64 --led-gpio-mapping=adafruit-hat-pwm --led-brightness=20 --led-slowdown-gpio=4 --testScChampions 2
```
And by temporarily modifying constructor to set a team id, and modifying `config/config.json` to include entry for `stanley_cup_champions` using: 
```
sudo python3 src/main.py --led-rows=32 --led-cols=64 --led-gpio-mapping=adafruit-hat-pwm --led-brightness=20 --led-slowdown-gpio=4 
```
Without this change, if you add `stanley_cup_champions` to the list of boards you would like to display, the process crashes with:
```
Traceback (most recent call last):
  File "src/main.py", line 139, in <module>
    run()
  File "src/main.py", line 134, in run
    MainRenderer(matrix, data, sleepEvent).render()
  File "/home/pi/nhl-led-scoreboard/src/renderer/main.py", line 59, in render
    self.test_stanley_cup_champion(self.data.config.testScChampions)
  File "/home/pi/nhl-led-scoreboard/src/renderer/main.py", line 353, in test_stanley_cup_champion
    StanleyCupChampions(self.data, team_id, self.matrix, self.sleepEvent).render()
TypeError: __init__() takes 4 positional arguments but 5 were given
```

Please let me know if there are any edits you would like me to make. 