### PR TITLE
Fixed off_day/division in schema, sample JSON to match

### DIFF
--- a/config/config.json.sample
+++ b/config/config.json.sample
@@ -49,7 +49,7 @@
 		"standings": {
 			"preferred_standings_only": true,
 			"standing_type": "wild_card",
-			"divisions": "central",
+			"divisions": "north",
 			"conference": "eastern"
 		},
 		"clock": {

--- a/config/config.json.save
+++ b/config/config.json.save
@@ -1,7 +1,7 @@
 {
     "debug": false,
     "loglevel": "INFO",
-    "live_mode": false,
+    "live_mode": true,
     "preferences": {
         "time_format": "12h",
         "end_of_day": "8:00",
@@ -51,7 +51,7 @@
         "standings": {
             "preferred_standings_only": true,
             "standing_type": "wild_card",
-            "divisions": "central",
+            "divisions": "north",
             "conference": "eastern"
         },
         "clock": {

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -139,7 +139,7 @@
                     "$id": "#/properties/preferences/properties/teams",
                     "type": "array",
                     "title": "teams",
-                    "description": "List of preferred teams. First one in the list is considered the favorite. If left empty, the scoreboard will be in offday mode",
+                    "description": "List of preferred teams. First one in the list is considered the favorite. If left empty, the scoreboard will be in off_day mode",
                     "default": ["Avalanche"],
                     "examples": [
                             "Jets",
@@ -283,7 +283,7 @@
                         "$id": "#/properties/states/properties/off_day/items",
                         "type": "string",
                         "title": "boards",
-                        "description": "Boards to display on offday",
+                        "description": "Boards to display on off_day",
                         "default": "",
                         "examples": [
                             "clock",
@@ -429,7 +429,7 @@
                     "standings": {
                         "standing_type": "wild_card",
                         "preferred_standings_only": true,
-                        "divisions": "central",
+                        "divisions": "north",
                         "conference": "eastern"
                     },
                     "covid19": {
@@ -554,7 +554,7 @@
                     "default": {},
                     "examples": [
                         {
-                            "divisions": "central",
+                            "divisions": "north",
                             "conference": "eastern",
                             "standing_type": "wild_card",
                             "preferred_standings_only": true
@@ -596,17 +596,13 @@
                         "divisions": {
                             "$id": "#/properties/boards/properties/standings/properties/divisions",
                             "type": "string",
-                            "title": "divisions (central, pacific, atlanic, metropolitan",
+                            "title": "divisions (north, south, east, west)",
                             "description": "Your preferred division",
                             "default": "",
                             "examples": [
-                                "central"
+                                "north"
                             ],
                             "enum": [
-                                "central",
-                                "pacific", 
-                                "atlanic", 
-                                "metropolitan",
                                 "north",
                                 "west",
                                 "south",
@@ -1378,7 +1374,7 @@
                             ],
                             "enum": [
                                 "always",
-                                "offday"
+                                "off_day"
                             ]
                         },
                         "daytime": {

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -52,7 +52,7 @@
             "type": "boolean",
             "title": "live_mode",
             "description": "Enable the live mode which show live game data of your favorite team.",
-            "default": false,
+            "default": true,
             "examples": [
                 true
             ]
@@ -405,11 +405,11 @@
                             "wxalert",
                             "wxforecast",
                             "scoreticker",
-							"seriesticker",
+			    "seriesticker",
                             "standings",
-							"team_summary",
-							"stanley_cup_champions",
-							"christmas",
+			    "team_summary",
+			    "stanley_cup_champions",
+			    "christmas",
                             "clock",
                             "covid19",
                             "weather"
@@ -596,17 +596,20 @@
                         "divisions": {
                             "$id": "#/properties/boards/properties/standings/properties/divisions",
                             "type": "string",
-                            "title": "divisions (north, south, east, west)",
+                            "title": "divisions (north, central, east, west)",
                             "description": "Your preferred division",
                             "default": "",
                             "examples": [
                                 "north"
                             ],
                             "enum": [
-                                "north",
-                                "west",
-                                "south",
-                                "east"
+								"north",
+								"east",
+								"west",
+								"central",
+								"atlantic",
+								"metropolitan",
+								"pacific"
                             ]
                         },
                         "conference": {

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -33,17 +33,17 @@
             "description": "Level of logs to show in output.  Can be DEBUG, INFO, WARN, ERROR, CRITICAL  DEBUG is same as setting debug to true ",
             "default": "INFO",
             "examples": [
-                "DEBUG", 
-                "INFO", 
-                "WARNING", 
-                "ERROR", 
+                "DEBUG",
+                "INFO",
+                "WARNING",
+                "ERROR",
                 "CRITICAL"
             ],
             "enum": [
-                "DEBUG", 
-                "INFO", 
-                "WARNING", 
-                "ERROR", 
+                "DEBUG",
+                "INFO",
+                "WARNING",
+                "ERROR",
                 "CRITICAL"
             ]
         },
@@ -98,10 +98,12 @@
                     "description": "The format in which the game start time will be displayed.",
                     "default": "12h",
                     "examples": [
-                        "12h", "24h"
+                        "12h",
+                        "24h"
                     ],
                     "enum": [
-                        "12h", "24h"
+                        "12h",
+                        "24h"
                     ]
                 },
                 "end_of_day": {
@@ -122,7 +124,9 @@
                     "description": "Overrides latitude and longitude lookup by IP address.  Used by dimmer and weather",
                     "default": "",
                     "examples": [
-                        "City,State/Province", "Winnipeg, MB", "49.8844,-97.147"
+                        "City,State/Province",
+                        "Winnipeg, MB",
+                        "49.8844,-97.147"
                     ]
                 },
                 "live_game_refresh_rate": {
@@ -140,12 +144,14 @@
                     "type": "array",
                     "title": "teams",
                     "description": "List of preferred teams. First one in the list is considered the favorite. If left empty, the scoreboard will be in off_day mode",
-                    "default": ["Avalanche"],
+                    "default": [
+                        "Avalanche"
+                    ],
                     "examples": [
-                            "Jets",
-                            "Canadiens",
-                            "Oilers"
-                        ],
+                        "Jets",
+                        "Canadiens",
+                        "Oilers"
+                    ],
                     "additionalItems": true,
                     "items": {
                         "$id": "#/properties/preferences/properties/teams/items",
@@ -159,38 +165,38 @@
                             "Oilers"
                         ],
                         "enum": [
-							"Avalanche", 
-							"Blackhawks", 
-							"Blue Jackets", 
-							"Blues", 
-							"Bruins", 
-							"Canadiens", 
-							"Canucks", 
-							"Capitals", 
-							"Coyotes", 
-							"Devils", 
-							"Ducks", 
-							"Flames", 
-							"Flyers", 
-							"Golden Knights", 
-							"Hurricanes", 
-							"Islanders", 
-							"Jets", 
-							"Kings", 
-							"Lightning", 
-							"Maple Leafs", 
-							"Oilers", 
-							"Panthers", 
-							"Penguins", 
-							"Predators", 
-							"Rangers", 
-							"Red Wings", 
-							"Sabres", 
-							"Senators", 
-							"Sharks", 
-							"Stars", 
-							"Wild"
-						]
+                            "Avalanche",
+                            "Blackhawks",
+                            "Blue Jackets",
+                            "Blues",
+                            "Bruins",
+                            "Canadiens",
+                            "Canucks",
+                            "Capitals",
+                            "Coyotes",
+                            "Devils",
+                            "Ducks",
+                            "Flames",
+                            "Flyers",
+                            "Golden Knights",
+                            "Hurricanes",
+                            "Islanders",
+                            "Jets",
+                            "Kings",
+                            "Lightning",
+                            "Maple Leafs",
+                            "Oilers",
+                            "Panthers",
+                            "Penguins",
+                            "Predators",
+                            "Rangers",
+                            "Red Wings",
+                            "Sabres",
+                            "Senators",
+                            "Sharks",
+                            "Stars",
+                            "Wild"
+                        ]
                     }
                 },
                 "sog_display_frequency": {
@@ -293,11 +299,11 @@
                             "wxalert",
                             "wxforecast",
                             "scoreticker",
-							"seriesticker",
+                            "seriesticker",
                             "standings",
-							"team_summary",
-							"stanley_cup_champions",
-							"christmas",
+                            "team_summary",
+                            "stanley_cup_champions",
+                            "christmas",
                             "clock",
                             "covid19",
                             "weather"
@@ -333,11 +339,11 @@
                             "wxalert",
                             "wxforecast",
                             "scoreticker",
-							"seriesticker",
+                            "seriesticker",
                             "standings",
-							"team_summary",
-							"stanley_cup_champions",
-							"christmas",
+                            "team_summary",
+                            "stanley_cup_champions",
+                            "christmas",
                             "clock",
                             "covid19",
                             "weather"
@@ -369,11 +375,11 @@
                             "wxalert",
                             "wxforecast",
                             "scoreticker",
-							"seriesticker",
+                            "seriesticker",
                             "standings",
-							"team_summary",
-							"stanley_cup_champions",
-							"christmas",
+                            "team_summary",
+                            "stanley_cup_champions",
+                            "christmas",
                             "clock",
                             "covid19",
                             "weather"
@@ -405,11 +411,11 @@
                             "wxalert",
                             "wxforecast",
                             "scoreticker",
-			    "seriesticker",
+                            "seriesticker",
                             "standings",
-			    "team_summary",
-			    "stanley_cup_champions",
-			    "christmas",
+                            "team_summary",
+                            "stanley_cup_champions",
+                            "christmas",
                             "clock",
                             "covid19",
                             "weather"
@@ -590,7 +596,7 @@
                             "enum": [
                                 "conference",
                                 "division",
-                                "wild_card"                                
+                                "wild_card"
                             ]
                         },
                         "divisions": {
@@ -603,13 +609,13 @@
                                 "north"
                             ],
                             "enum": [
-								"north",
-								"east",
-								"west",
-								"central",
-								"atlantic",
-								"metropolitan",
-								"pacific"
+                                "north",
+                                "east",
+                                "west",
+                                "central",
+                                "atlantic",
+                                "metropolitan",
+                                "pacific"
                             ]
                         },
                         "conference": {
@@ -1046,7 +1052,8 @@
                             "description": "What data feed is provide alert data.  EC for Environment Canada or NWS for the National Weather Service in the US",
                             "default": "",
                             "examples": [
-                                "EC", "NWS"
+                                "EC",
+                                "NWS"
                             ]
                         },
                         "update_freq": {
@@ -1121,9 +1128,7 @@
                         }
                     }
                 }
-            
             }
-            
         },
         "sbio": {
             "$id": "#/properties/sbio",
@@ -1184,14 +1189,14 @@
                     "default": {},
                     "examples": [
                         {
-                                "enabled": true,
-                                "animations": true,
-                                "start": "22:00",
-                                "stop": "22:05",
-                                "data_updates": false,
-                                "motionsensor": true,
-                                "pin": 24,
-                                "delay": 30
+                            "enabled": true,
+                            "animations": true,
+                            "start": "22:00",
+                            "stop": "22:05",
+                            "data_updates": false,
+                            "motionsensor": true,
+                            "pin": 24,
+                            "delay": 30
                         }
                     ],
                     "additionalProperties": true,
@@ -1338,11 +1343,11 @@
                             "description": "Hardware (adafruit TSL2591 light sensor) or software (based on your IP address)",
                             "default": "",
                             "examples": [
-                                "software", 
+                                "software",
                                 "hardware"
                             ],
                             "enum": [
-                                "software", 
+                                "software",
                                 "hardware"
                             ]
                         },
@@ -1495,7 +1500,7 @@
                             "type": "integer",
                             "title": "pin",
                             "description": "The gpiozero number pin your button is connected to",
-                            "default":25,
+                            "default": 25,
                             "examples": [
                                 25
                             ]
@@ -1570,7 +1575,6 @@
                                 "weather",
                                 "standings"
                             ]
-                            
                         },
                         "state_triggered1_process": {
                             "$id": "#/properties/sbio/properties/pushbutton/properties/state_triggered1_process",
@@ -1586,6 +1590,5 @@
                 }
             }
         }
-        
     }
 }


### PR DESCRIPTION
Schema was updated previously in PR #204 by @falkyre to include divisions, along with other changes.

- This fixes those values missing from the recent `dev` branch merge to `beta`, and updates sample files accordingly to reflect recent changes.
-  Sample JSON updated.
- Also includes offday => off_day changes.

Note: Schema to be updated to original values for 2021-2022 season. (atlantic, central, metropolitan, pacific)