### PR TITLE
Use diffPatch endpoint for game overview

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ nameparser==1.0.6
 pillow==7.1.2
 dbus-python
 iso6709
+dotty-dict>=1.3.0

--- a/src/nhl_api/data.py
+++ b/src/nhl_api/data.py
@@ -52,7 +52,12 @@ def get_player(playerId):
 
 def get_overview(game_id):
     if game_id in scoreboards:
-        return get_diff_overview(game_id)
+        try:
+          return get_diff_overview(game_id)
+        except ValueError:
+        #    return full overview if diff fails
+           return get_full_overview(game_id)
+
 
     return get_full_overview(game_id)
 

--- a/src/nhl_api/data.py
+++ b/src/nhl_api/data.py
@@ -2,7 +2,6 @@ import json
 import requests
 import debug
 import dotty_dict
-import logging
 
 """
     TODO:
@@ -27,7 +26,6 @@ REQUEST_TIMEOUT = 5
 
 TIMEOUT_TESTING = 0.001  # TO DELETE
 
-logger = logging.getLogger('scoreboard')
 scoreboards = {}
 
 
@@ -91,18 +89,23 @@ def get_diff_overview(game_id):
 
 def apply_patches(data, diffs):
     dot = dotty_dict.Dotty(data, separator='/')
-    for patches in diffs:
-        logger.debug(patches)
-        for patch in patches['diff']:
-            path = patch['path'].strip('/')
-            if patch['op'] in ['replace', 'add']:
-                dot[path] = patch['value']
-            elif patch['op'] in ['remove']:
-                if dot.get(path):
-                    del dot[path]
-            else:
-                return get_full_overview(data['gamePk'])
-    return dot.to_dict()
+    try:
+        for patches in diffs:
+            debug.log(patches)
+            for patch in patches['diff']:
+                path = patch['path'].strip('/')
+                if patch['op'] in ['replace', 'add']:
+                    dot[path] = patch['value']
+                elif patch['op'] in ['remove']:
+                    if dot.get(path):
+                        del dot[path]
+                else:
+                    return get_full_overview(data['gamePk'])
+        return dot.to_dict()
+    except:
+        debug.log(diffs)
+        return get_full_overview(data['gamePk'])
+
 
 
 def get_game_status():

--- a/src/nhl_api/data.py
+++ b/src/nhl_api/data.py
@@ -2,6 +2,7 @@ import json
 import requests
 import debug
 import dotty_dict
+import logging
 
 """
     TODO:
@@ -25,6 +26,8 @@ SERIES_RECORD = "https://records.nhl.com/site/api/playoff-series?cayenneExp=play
 REQUEST_TIMEOUT = 5
 
 TIMEOUT_TESTING = 0.001  # TO DELETE
+
+logger = logging.getLogger('scoreboard')
 scoreboards = {}
 
 
@@ -89,6 +92,7 @@ def get_diff_overview(game_id):
 def apply_patches(data, diffs):
     dot = dotty_dict.Dotty(data, separator='/')
     for patches in diffs:
+        logger.debug(patches)
         for patch in patches['diff']:
             path = patch['path'].strip('/')
             if patch['op'] in ['replace', 'add']:

--- a/src/nhl_api/data.py
+++ b/src/nhl_api/data.py
@@ -64,7 +64,7 @@ def get_overview(game_id):
 
 def get_full_overview(game_id):
     try:
-        data = requests.get(OVERVIEW_URL.format(game_id), timeout=REQUEST_TIMEOUT)
+        data = requests.get(OVERVIEW_URL.format(game_id), timeout=REQUEST_TIMEOUT).json()
         scoreboards[game_id] = data
         # data = dummie_overview()
         return data

--- a/src/nhl_api/game.py
+++ b/src/nhl_api/game.py
@@ -102,8 +102,7 @@ class GameScoreboard(object):
 
 
 def overview(game_id):
-    data = nhl_api.data.get_overview(game_id)
-    parsed = data.json()
+    parsed = nhl_api.data.get_overview(game_id)
     # Top level information (General)
     id = parsed['gamePk']
     time_stamp = parsed['gameData']['game']


### PR DESCRIPTION
Pardon my terrible python. This is definitely not ready to get merged in so I'll mark it as draft, but I thought I'd throw something rough together based on the diffPatch discussion we had on discord in case it was at all helpful.

I tested this and it works, but there is a few things that could probably be fixed up. 

Red Flags:
1. This just stuffs the overview scorecard into a dict in memory and never clears it. We probably want to delete it when the game ends.
2. There is nothing to handle cases where the diffPatch url returns the scoreboard instead of the diffPatches. I didn't observe this while I was cobbling this together, but I know that this can happen. Probably just needs a try...catch around it that then returns the '.json()` but i dunno

Yellow Flags:
1. This adds a dependency for `dotty-dict`. Not sure how we feel about added dependencies, but as I said, my python kinda sucks and this helped make my code readable. 
2.  Instead of `data.overview` returning the response object which gets `.json`ed by its consumer, it returns the dictionary. Maybe not a big deal but I bring it up since it might go against an expected pattern here

There's also some optimisation opportunities here surrounding the use of `dotty-dict`. I don't know what the overhead on using this library is, but we're wrapping this dict with it once every time we run `apply_patches`, we could likely just keep the wrapped dict in memory instead of doing that each time.