### PR TITLE
Minor Schema Changes: Examples -> Defaults, Fixed Patterns for 12hr Time

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -16,31 +16,28 @@
         "sbio"
     ],
     "definitions": {
-      	"boards_list": {
-          	"enum": [
-              "wxalert",
-              "wxforecast",
-              "scoreticker",
-              "seriesticker",
-              "standings",
-              "team_summary",
-              "stanley_cup_champions",
-              "christmas",
-              "clock",
-              "weather"
+        "boards_list": {
+            "enum": [
+                "wxalert",
+                "wxforecast",
+                "scoreticker",
+                "seriesticker",
+                "standings",
+                "team_summary",
+                "stanley_cup_champions",
+                "christmas",
+                "clock",
+                "weather"
             ]
         }
-    },    
+    },
     "properties": {
         "debug": {
             "$id": "#/properties/debug",
             "type": "boolean",
             "title": "debug",
             "description": "Enable the debug mode which show on your console what the scoreboard",
-            "default": false,
-            "examples": [
-                true
-            ]
+            "default": false
         },
         "loglevel": {
             "$id": "#/properties/loglevel",
@@ -48,13 +45,6 @@
             "title": "loglevel",
             "description": "Level of logs to show in output.  Can be DEBUG, INFO, WARN, ERROR, CRITICAL  DEBUG is same as setting debug to true ",
             "default": "INFO",
-            "examples": [
-                "DEBUG",
-                "INFO",
-                "WARNING",
-                "ERROR",
-                "CRITICAL"
-            ],
             "enum": [
                 "DEBUG",
                 "INFO",
@@ -68,10 +58,7 @@
             "type": "boolean",
             "title": "live_mode",
             "description": "Enable the live mode which show live game data of your favorite team.",
-            "default": true,
-            "examples": [
-                true
-            ]
+            "default": true
         },
         "preferences": {
             "$id": "#/properties/preferences",
@@ -79,23 +66,6 @@
             "title": "preferences",
             "description": "All data related options",
             "default": {},
-            "examples": [
-                {
-                    "location": "Winnipeg, MB",
-                    "sog_display_frequency": 4,
-                    "end_of_day": "10:00",
-                    "live_game_refresh_rate": 10,
-                    "teams": [
-                        "Jets",
-                        "Canadiens",
-                        "Oilers"
-                    ],
-                    "time_format": "12h",
-                    "goal_animations": {
-                        "pref_team_only": true
-                    }
-                }
-            ],
             "additionalProperties": true,
             "required": [
                 "time_format",
@@ -113,10 +83,6 @@
                     "title": "time_format(12h or 24h)",
                     "description": "The format in which the game start time will be displayed.",
                     "default": "12h",
-                    "examples": [
-                        "12h",
-                        "24h"
-                    ],
                     "enum": [
                         "12h",
                         "24h"
@@ -125,19 +91,16 @@
                 "end_of_day": {
                     "$id": "#/properties/preferences/properties/end_of_day",
                     "type": "string",
-                    "pattern": "([01]?[0-9]|2[0-3]):[0-5][0-9]",
                     "title": "end_of_day",
                     "description": "A 24-hour time you wish to consider the end of the previous day before starting to display the current day's games.",
                     "default": "12:00",
-                    "examples": [
-                        "10:00"
-                    ]
+                    "pattern": "([01]?[0-9]|2[0-3]):[0-5][0-9]"
                 },
                 "location": {
                     "$id": "#/properties/preferences/properties/location",
                     "type": "string",
                     "title": "location",
-                    "description": "Overrides latitude and longitude lookup by IP address.  Used by dimmer and weather",
+                    "description": "Overrides latitude and longitude lookup by IP address. Used by dimmer and weather",
                     "default": "",
                     "examples": [
                         "City,State/Province",
@@ -150,36 +113,23 @@
                     "type": "integer",
                     "title": "live_game_refresh_rate",
                     "description": "The rate at which a live game will call the NHL API to catch the new data. Do not go under 10 seconds as it's pointless and will affect your scoreboard performance.(Default 15 sec)",
-                    "default": 15,
-                    "examples": [
-                        10
-                    ]
+                    "default": 15
                 },
                 "teams": {
                     "$id": "#/properties/preferences/properties/teams",
                     "type": "array",
-                    "title": "teams",
+                    "title": "Teams",
                     "description": "List of preferred teams. First one in the list is considered the favorite. If left empty, the scoreboard will be in off_day mode",
                     "default": [
                         "Avalanche"
-                    ],
-                    "examples": [
-                        "Jets",
-                        "Canadiens",
-                        "Oilers"
                     ],
                     "additionalItems": true,
                     "items": {
                         "$id": "#/properties/preferences/properties/teams/items",
                         "type": "string",
-                        "title": "teams",
-                        "description": "Teams selected to display",
+                        "title": "Team",
+                        "description": "Team selected to display",
                         "default": "Avalanche",
-                        "examples": [
-                            "Jets",
-                            "Canadiens",
-                            "Oilers"
-                        ],
                         "enum": [
                             "Avalanche",
                             "Blackhawks",
@@ -220,10 +170,7 @@
                     "type": "integer",
                     "title": "sog_display_frequency",
                     "description": "How often the shots on goal are updated",
-                    "default": 4,
-                    "examples": [
-                        4
-                    ]
+                    "default": 4
                 },
                 "goal_animations": {
                     "$id": "#/properties/preferences/goal_animations",
@@ -231,11 +178,6 @@
                     "title": "goal_animations",
                     "description": "The goal animations can be set for both teams of just the preferred teams",
                     "default": true,
-                    "examples": [
-                        {
-                            "pref_team_only": true
-                        }
-                    ],
                     "additionalProperties": true,
                     "required": [
                         "pref_team_only"
@@ -246,10 +188,7 @@
                             "type": "boolean",
                             "title": "pref_team_only",
                             "description": "Show only your preferred team goal animation or show both",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "default": false
                         }
                     }
                 }
@@ -260,26 +199,23 @@
             "type": "object",
             "title": "states",
             "description": "If the live mode is enabled, the scoreboard will go through different states depending on the current situation. For each state, you can define which of the available board you want the scoreboard to show. For example, if one of my preferred team has a game scheduled on the current day, during the day, the scoreboard will be in the scheduled state. I personally like to have all the data possible shown during the day so I'll set the all the boards in the scheduled setting.",
-            "default": {},
-            "examples": [
-                {
-                    "off_day": [
-                        "clock",
-                        "weather"
-                    ],
-                    "scheduled": [
-                        "standings",
-                        "scoreticker",
-                        "clock"
-                    ],
-                    "post_game": [
-                        "scoreticker"
-                    ],
-                    "intermission": [
-                        "clock"
-                    ]
-                }
-            ],
+            "default": {
+                "off_day": [
+                    "clock",
+                    "weather"
+                ],
+                "scheduled": [
+                    "standings",
+                    "scoreticker",
+                    "clock"
+                ],
+                "post_game": [
+                    "scoreticker"
+                ],
+                "intermission": [
+                    "clock"
+                ]
+            },
             "additionalProperties": true,
             "required": [
                 "off_day",
@@ -293,12 +229,9 @@
                     "type": "array",
                     "title": "off_day",
                     "description": "Offday is when your team is not playing.  This could be off season as well",
-                    "default": [],
-                    "examples": [
-                        [
-                            "clock",
-                            "weather"
-                        ]
+                    "default": [
+                        "clock",
+                        "weather"
                     ],
                     "additionalItems": true,
                     "items": {
@@ -306,8 +239,7 @@
                         "type": "string",
                         "title": "boards",
                         "description": "Boards to display on off_day",
-                        "default": "",
-                        "examples": [
+                        "default": [
                             "clock",
                             "weather"
                         ],
@@ -319,13 +251,10 @@
                     "type": "array",
                     "title": "scheduled",
                     "description": "Scheduled is for when you team will be playing",
-                    "default": [],
-                    "examples": [
-                        [
-                            "clock",
-                            "standings",
-                            "scoreticker"
-                        ]
+                    "default": [
+                        "clock",
+                        "standings",
+                        "scoreticker"
                     ],
                     "additionalItems": true,
                     "items": {
@@ -333,12 +262,7 @@
                         "type": "string",
                         "title": "boards",
                         "description": "Boards to display on sceduled",
-                        "default": "",
-                        "examples": [
-                            "clock",
-                            "standings",
-                            "scoreticker"
-                        ],
+                        "default": "scoreticker",
                         "$ref": "#/definitions/boards_list"
                     }
                 },
@@ -347,11 +271,11 @@
                     "type": "array",
                     "title": "intermission",
                     "description": "What to display during itermission betweeen periods",
-                    "default": [],
-                    "examples": [
-                        [
-                            "clock"
-                        ]
+                    "default": [
+                        "clock",
+                        "scoreticker",
+                        "team_summary",
+                        "standings"
                     ],
                     "additionalItems": true,
                     "items": {
@@ -359,10 +283,7 @@
                         "type": "string",
                         "title": "boards",
                         "description": "Boards to display at intermission",
-                        "default": "",
-                        "examples": [
-                            "clock"
-                        ],
+                        "default": "scoreticker",
                         "$ref": "#/definitions/boards_list"
                     }
                 },
@@ -371,11 +292,8 @@
                     "type": "array",
                     "title": "post_game",
                     "description": "What to display after the game is done",
-                    "default": [],
-                    "examples": [
-                        [
-                            "scoreticker"
-                        ]
+                    "default": [
+                        "scoreticker"
                     ],
                     "additionalItems": true,
                     "items": {
@@ -383,10 +301,7 @@
                         "type": "string",
                         "title": "boards",
                         "description": "Boards to display for post game",
-                        "default": "",
-                        "examples": [
-                            "scoreticker"
-                        ],
+                        "default": "scoreticker",
                         "$ref": "#/definitions/boards_list"
                     }
                 }
@@ -397,31 +312,30 @@
             "type": "object",
             "title": "boards",
             "description": "All possible boards that can be displayed and their settings",
-            "default": {},
-            "examples": [
-                {
-                    "standings": {
-                        "standing_type": "wild_card",
-                        "preferred_standings_only": true,
-                        "divisions": "north",
-                        "conference": "eastern"
-                    },
-                    "clock": {
-                        "hide_indicator": false,
-                        "duration": 60
-                    },
-                    "scoreticker": {
-                        "rotation_rate": 5,
-                        "preferred_teams_only": false
-                    }
+            "default": {
+                "standings": {
+                    "standing_type": "wild_card",
+                    "preferred_standings_only": true,
+                    "divisions": "north",
+                    "conference": "eastern"
+                },
+                "clock": {
+                    "hide_indicator": false,
+                    "duration": 60
+                },
+                "scoreticker": {
+                    "rotation_rate": 5,
+                    "preferred_teams_only": false
                 }
-            ],
+            },
             "additionalProperties": true,
             "required": [
                 "scoreticker",
+                "seriesticker",
                 "standings",
                 "clock",
-                "weather"
+                "weather",
+                "wxalert"
             ],
             "properties": {
                 "scoreticker": {
@@ -429,13 +343,10 @@
                     "type": "object",
                     "title": "scoreticker",
                     "description": "This is basically like the generic score ticker you see during a game on TV of sports news showing the result or the status of the other games in the league",
-                    "default": {},
-                    "examples": [
-                        {
-                            "preferred_teams_only": false,
-                            "rotation_rate": 5
-                        }
-                    ],
+                    "default": {
+                        "preferred_teams_only": false,
+                        "rotation_rate": 5
+                    },
                     "additionalProperties": true,
                     "required": [
                         "preferred_teams_only",
@@ -447,20 +358,14 @@
                             "type": "boolean",
                             "title": "preferred_teams_only",
                             "description": "Choose between showing all the games of the day or just the ones your preferred teams are playing",
-                            "default": false,
-                            "examples": [
-                                false
-                            ]
+                            "default": false
                         },
                         "rotation_rate": {
                             "$id": "#/properties/boards/properties/scoreticker/properties/rotation_rate",
                             "type": "integer",
                             "title": "rotation_rate",
                             "description": "Duration at which each games are shown on screen.",
-                            "default": 5,
-                            "examples": [
-                                5
-                            ]
+                            "default": 5
                         }
                     }
                 },
@@ -469,13 +374,10 @@
                     "type": "object",
                     "title": "seriesticker",
                     "description": "Just like the scoreticker, this is showing playoff series status with a table sporting each game scores and result.",
-                    "default": {},
-                    "examples": [
-                        {
-                            "preferred_teams_only": false,
-                            "rotation_rate": 5
-                        }
-                    ],
+                    "default": {
+                        "preferred_teams_only": false,
+                        "rotation_rate": 5
+                    },
                     "additionalProperties": true,
                     "required": [
                         "preferred_teams_only",
@@ -487,20 +389,14 @@
                             "type": "boolean",
                             "title": "preferred_teams_only",
                             "description": "Choose between showing all series of the current round of playoff or just the ones your preferred teams are part of.",
-                            "default": false,
-                            "examples": [
-                                false
-                            ]
+                            "default": false
                         },
                         "rotation_rate": {
                             "$id": "#/properties/boards/properties/seriesticker/properties/rotation_rate",
                             "type": "integer",
                             "title": "rotation_rate",
                             "description": "Duration at which each series are shown on screen.",
-                            "default": 5,
-                            "examples": [
-                                5
-                            ]
+                            "default": 5
                         }
                     }
                 },
@@ -509,15 +405,12 @@
                     "type": "object",
                     "title": "standings",
                     "description": "Self-explanatory, it shows the current standings. Currently, you can choose between showing standings by conference or by divisions. Wildcard standings are coming soon.",
-                    "default": {},
-                    "examples": [
-                        {
-                            "divisions": "north",
-                            "conference": "eastern",
-                            "standing_type": "wild_card",
-                            "preferred_standings_only": true
-                        }
-                    ],
+                    "default": {
+                        "divisions": "north",
+                        "conference": "eastern",
+                        "standing_type": "wild_card",
+                        "preferred_standings_only": true
+                    },
                     "additionalProperties": true,
                     "required": [
                         "preferred_standings_only",
@@ -531,10 +424,7 @@
                             "type": "boolean",
                             "title": "preferred_standings_only",
                             "description": "Choose between showing all the standings or only the the preferred division and conference.",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "default": false
                         },
                         "standing_type": {
                             "$id": "#/properties/boards/properties/standings/properties/standing_type",
@@ -542,9 +432,6 @@
                             "title": "standing_type",
                             "description": "Option to choose the type of standings to display. conference if set by default.",
                             "default": "conference",
-                            "examples": [
-                                "wild_card"
-                            ],
                             "enum": [
                                 "conference",
                                 "division",
@@ -556,10 +443,7 @@
                             "type": "string",
                             "title": "divisions (north, central, east, west)",
                             "description": "Your preferred division",
-                            "default": "",
-                            "examples": [
-                                "north"
-                            ],
+                            "default": "north",
                             "enum": [
                                 "north",
                                 "east",
@@ -575,10 +459,7 @@
                             "type": "string",
                             "title": "conference (eastern or western)",
                             "description": "Your preferred conference",
-                            "default": "",
-                            "examples": [
-                                "eastern"
-                            ],
+                            "default": "eastern",
                             "enum": [
                                 "eastern",
                                 "western"
@@ -591,17 +472,14 @@
                     "type": "object",
                     "title": "clock",
                     "description": "Show the current time either in 24h or 12h format.",
-                    "default": {},
-                    "examples": [
-                        {
-                            "hide_indicator": false,
-                            "duration": 60,
-                            "preferred_team_colors": true,
-                            "clock_rgb": "234,234,78",
-                            "date_rgb": "78,234,234",
-                            "flash_seconds": true
-                        }
-                    ],
+                    "default": {
+                        "hide_indicator": false,
+                        "duration": 60,
+                        "preferred_team_colors": true,
+                        "clock_rgb": "234,234,78",
+                        "date_rgb": "78,234,234",
+                        "flash_seconds": false
+                    },
                     "additionalProperties": true,
                     "required": [
                         "duration",
@@ -617,60 +495,42 @@
                             "type": "integer",
                             "title": "duration",
                             "description": "How long to show the clock",
-                            "default": 60,
-                            "examples": [
-                                60
-                            ]
+                            "default": 60
                         },
                         "hide_indicator": {
                             "$id": "#/properties/boards/properties/clock/properties/hide_indicator",
                             "type": "boolean",
                             "title": "hide_indicator",
                             "description": "Hide the red bar no network indicator on the bottom",
-                            "default": false,
-                            "examples": [
-                                false
-                            ]
+                            "default": false
                         },
                         "preferred_team_colors": {
                             "$id": "#/properties/boards/properties/clock/properties/preferred_team_colors",
                             "type": "boolean",
                             "title": "preferred_team_colors",
                             "description": "Use your first preferred team's colors for clock.  The primary color will be used for clock numbers, while the team text color will be used for the date/weather and AM/PM",
-                            "default": false,
-                            "examples": [
-                                false
-                            ]
+                            "default": false
                         },
                         "clock_rgb": {
                             "$id": "#/properties/boards/properties/clock/properties/clock_rgb",
                             "type": "string",
                             "title": "clock_rgb",
                             "description": "Set the clock numbers to the RGB value if preferred_team_colors set to false.  This must be in the form R,G,B",
-                            "default": false,
-                            "examples": [
-                                "230,230,23"
-                            ]
+                            "default": false
                         },
                         "date_rgb": {
                             "$id": "#/properties/boards/properties/clock/properties/date_rgb",
                             "type": "string",
                             "title": "date_rgb",
-                            "description": "Set the date/weather and AM/PM text to the RGB value if preferred_team_colors set to false.  This must be in the form R,G,B",
-                            "default": false,
-                            "examples": [
-                                "230,230,23"
-                            ]
+                            "description": "Set the date/weather and AM/PM text to the RGB value if preferred_team_colors set to false.  This must be in the form R,G,B ie. 230,230,23",
+                            "default": false
                         },
                         "flash_seconds": {
                             "$id": "#/properties/boards/properties/clock/properties/flash_seconds",
                             "type": "boolean",
                             "title": "flash_seconds",
                             "description": "Flash the seconds (:) if true.  If set to false, dont show the (:)",
-                            "default": false,
-                            "examples": [
-                                false
-                            ]
+                            "default": false
                         }
                     }
                 },
@@ -679,22 +539,19 @@
                     "type": "object",
                     "title": "weather",
                     "description": "Settings for the weather data provider",
-                    "default": {},
-                    "examples": [
-                        {
-                            "enabled": true,
-                            "view": "full",
-                            "data_feed": "EC",
-                            "owm_apikey": "9faxd10xa991x305xaed8x3dfcx4cdxf",
-                            "units": "metric",
-                            "update_freq": 5,
-                            "duration": 30,
-                            "show_on_clock": true,
-                            "forecast_enabled": true,
-                            "forecast_days": 3,
-                            "forecast_update": 1
-                        }
-                    ],
+                    "default": {
+                        "enabled": true,
+                        "view": "full",
+                        "data_feed": "EC",
+                        "owm_apikey": "",
+                        "units": "metric",
+                        "update_freq": 5,
+                        "duration": 30,
+                        "show_on_clock": true,
+                        "forecast_enabled": true,
+                        "forecast_days": 3,
+                        "forecast_update": 1
+                    },
                     "additionalProperties": true,
                     "required": [
                         "enabled",
@@ -715,29 +572,24 @@
                             "type": "boolean",
                             "title": "enabled",
                             "description": "Enable the weather thread to get your local weather.",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "default": false
                         },
                         "view": {
                             "$id": "#/properties/boards/properties/weather/properties/view",
                             "type": "string",
                             "title": "view",
                             "description": "Weather board full (3 page) or summary view (1 page)",
-                            "default": "full",
-                            "examples": [
-                                "full"
-                            ]
+                            "default": "full"
                         },
                         "units": {
                             "$id": "#/properties/boards/properties/weather/properties/units",
                             "type": "string",
                             "title": "units ",
                             "description": "Units to use for displaying the weather(metric or imperial)",
-                            "default": "",
-                            "examples": [
-                                "metric"
+                            "default": "metric",
+                            "enum": [
+                                "metric",
+                                "imperial"
                             ]
                         },
                         "duration": {
@@ -745,19 +597,17 @@
                             "type": "integer",
                             "title": "duration ",
                             "description": "The time to flip through the pages in the weather board.  If there are no alerts, this will be 3 pages, if there are alerts a 4th is added.  Minimum 30 seconds duration",
-                            "default": 30,
-                            "examples": [
-                                30
-                            ]
+                            "default": 30
                         },
                         "data_feed": {
                             "$id": "#/properties/boards/properties/weather/properties/data_feed",
                             "type": "string",
                             "title": "data_feed",
                             "description": "Where is the observation data coming from. You can use EC for Environment Canada, OWM for Open Weather Map (requires API KEY from https://openweathermap.org/api)",
-                            "default": "",
-                            "examples": [
-                                "EC"
+                            "default": "EC",
+                            "enum": [
+                                "EC",
+                                "OWM"
                             ]
                         },
                         "owm_apikey": {
@@ -766,6 +616,7 @@
                             "title": "owm_apikey",
                             "description": "API key required for when you use OpenWeatherMAP.  https://openweathermap.org/api",
                             "default": "",
+                            "maxLength": 32,
                             "examples": [
                                 "9ffxd195ax52a315xaed823xfcf4cdxf"
                             ]
@@ -775,30 +626,21 @@
                             "type": "integer",
                             "title": "update_freq ",
                             "description": "How often in minutes to refresh the weather and alerts feeds.",
-                            "default": 5,
-                            "examples": [
-                                5
-                            ]
+                            "default": 5
                         },
                         "show_on_clock": {
                             "$id": "#/properties/boards/properties/weather/properties/show_on_clock",
                             "type": "boolean",
                             "title": "show_on_clock",
                             "description": "Add the last observed temperature and humidity to the bottom of the clock board",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "default": false
                         },
                         "forecast_enabled": {
                             "$id": "#/properties/boards/properties/weather/properties/forecast_enabled",
                             "type": "boolean",
                             "title": "forecast_enabled",
                             "description": "Enable the weather forecast thread to get your local weather forecast up to 3 days.",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "default": false
                         },
                         "forecast_days": {
                             "$id": "#/properties/boards/properties/weather/properties/forecast_days",
@@ -806,19 +648,14 @@
                             "title": "forecast_days",
                             "description": "Number of forecast days to show (3 is the maximum).",
                             "default": 3,
-                            "examples": [
-                                3
-                            ]
+                            "maximum": 3
                         },
                         "forecast_update": {
                             "$id": "#/properties/boards/properties/weather/properties/forecast_update",
                             "type": "integer",
                             "title": "forecast_update",
                             "description": "How often to update forecast.  This is in hours",
-                            "default": 3,
-                            "examples": [
-                                3
-                            ]
+                            "default": 3
                         }
                     }
                 },
@@ -827,19 +664,16 @@
                     "type": "object",
                     "title": "wxalert",
                     "description": "Settings for the alerts data provider",
-                    "default": {},
-                    "examples": [
-                        {
-                            "scroll_alert": true,
-                            "alert_feed": "EC",
-                            "nws_show_expire": false,
-                            "alert_duration": 5,
-                            "alert_title": true,
-                            "update_freq": 5,
-                            "show_on_clock": true,
-                            "show_alerts": true
-                        }
-                    ],
+                    "default": {
+                        "scroll_alert": true,
+                        "alert_feed": "EC",
+                        "nws_show_expire": false,
+                        "alert_duration": 5,
+                        "alert_title": true,
+                        "update_freq": 5,
+                        "show_on_clock": true,
+                        "show_alerts": true
+                    },
                     "additionalProperties": true,
                     "required": [
                         "alert_feed",
@@ -857,8 +691,8 @@
                             "type": "string",
                             "title": "alert_feed",
                             "description": "What data feed is provide alert data.  EC for Environment Canada or NWS for the National Weather Service in the US",
-                            "default": "",
-                            "examples": [
+                            "default": "EC",
+                            "enum": [
                                 "EC",
                                 "NWS"
                             ]
@@ -868,70 +702,49 @@
                             "type": "integer",
                             "title": "update_freq ",
                             "description": "How often in minutes to refresh the weather and alerts feeds.",
-                            "default": 5,
-                            "examples": [
-                                5
-                            ]
+                            "default": 5
                         },
                         "nws_show_expire": {
                             "$id": "#/properties/boards/properties/wxalert/properties/nws_show_expire",
                             "type": "boolean",
                             "title": "nws_show_expire",
                             "description": "Show expire time (true) instead of effective time (false) of alert",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "default": false
                         },
                         "show_alerts": {
                             "$id": "#/properties/boards/properties/wxalert/properties/show_alerts",
                             "type": "boolean",
                             "title": "show_alerts",
                             "description": "Get weather alerts and display them",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "default": false
                         },
                         "alert_title": {
                             "$id": "#/properties/boards/properties/wxalert/properties/alert_title",
                             "type": "boolean",
                             "title": "alert_title",
                             "description": "On the initial alert page that will interrupt the normal board rotation, display on the top and bottom board the type of alert (WARNING, WATCH or ADVISORY)",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "default": false
                         },
                         "scroll_alert": {
                             "$id": "#/properties/boards/properties/wxalert/properties/scroll_alert",
                             "type": "boolean",
                             "title": "Scroll_alert",
                             "description": "Scroll the text of the alert on the initial alert page.  If you select false, a static page will be displayed that is the same as the 4th page on the weather board",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "default": false
                         },
                         "alert_duration": {
                             "$id": "#/properties/boards/properties/wxalert/properties/alert_duration",
                             "type": "integer",
                             "title": "alert_duration",
                             "description": "How long to display alert board (in seconds)",
-                            "default": 5,
-                            "examples": [
-                                5
-                            ]
+                            "default": 5
                         },
                         "show_on_clock": {
                             "$id": "#/properties/boards/properties/wxalert/properties/show_on_clock",
                             "type": "boolean",
                             "title": "show_on_clock",
                             "description": "Show Fred (active alert color square) on the bottom right corner of the clock board",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "default": false
                         }
                     }
                 }
@@ -943,44 +756,6 @@
             "title": "sbio",
             "description": "Scoreboard IO functions",
             "default": {},
-            "examples": [
-                {
-                    "screensaver": {
-                        "enabled": "true",
-                        "start": "22:00",
-                        "stop": "22:05",
-                        "data_updates": false,
-                        "motionsensor": true,
-                        "pin": 24,
-                        "delay": 30
-                    },
-                    "dimmer": {
-                        "frequency": 5,
-                        "light_level_lux": 10,
-                        "sunset_brightness": 5,
-                        "source": "software",
-                        "sunrise_brightness": 40,
-                        "enabled": true,
-                        "mode": "always",
-                        "daytime": "8:30AM",
-                        "nighttime": "5:30PM",
-                        "offset": 90
-                    },
-                    "pushbutton": {
-                        "state_triggered1": "weather",
-                        "bonnet": true,
-                        "pin": 25,
-                        "display_reboot": true,
-                        "state_triggered1_process": "",
-                        "poweroff_duration": 10,
-                        "poweroff_override_process": "",
-                        "reboot_override_process": "",
-                        "reboot_duration": 2,
-                        "display_halt": true,
-                        "enabled": true
-                    }
-                }
-            ],
             "additionalProperties": true,
             "required": [
                 "screensaver",
@@ -994,18 +769,6 @@
                     "title": "screensaver",
                     "description": "Ability to turn off screen and back on at set times",
                     "default": {},
-                    "examples": [
-                        {
-                            "enabled": true,
-                            "animations": true,
-                            "start": "22:00",
-                            "stop": "22:05",
-                            "data_updates": false,
-                            "motionsensor": true,
-                            "pin": 24,
-                            "delay": 30
-                        }
-                    ],
                     "additionalProperties": true,
                     "required": [
                         "enabled",
@@ -1020,82 +783,58 @@
                             "type": "boolean",
                             "title": "enabled",
                             "description": "Use the screensaver functionality",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "default": false
                         },
                         "animations": {
                             "$id": "#/properties/sbio/properties/screensaver/properties/animations",
                             "type": "boolean",
                             "title": "animations",
-                            "description": "Show anuimation on screensaver start (true) or go straight to black screen (false)",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "description": "Show animation on screensaver start (true) or go straight to black screen (false)",
+                            "default": false
                         },
                         "start": {
                             "$id": "#/properties/sbio/properties/screensaver/properties/start",
                             "type": "string",
-                            "pattern": "([01]?[0-9]|2[0-3]):[0-5][0-9]",
+                            "pattern": "((^([01][0-9]|2[0-3]):[0-5][0-9])$|^(([0][1-9]|1[0-2]):[0-5][0-9] [aApP][mM])$)",
                             "title": "start",
                             "description": "Time to start screensaver at (12h or 24h)",
-                            "default": "",
-                            "examples": [
-                                "22:00"
-                            ]
+                            "default": "01:00"
                         },
                         "stop": {
                             "$id": "#/properties/sbio/properties/screensaver/properties/stop",
                             "type": "string",
-                            "pattern": "([01]?[0-9]|2[0-3]):[0-5][0-9]",
+                            "pattern": "((^([01][0-9]|2[0-3]):[0-5][0-9])$|^(([0][1-9]|1[0-2]):[0-5][0-9] [aApP][mM])$)",
                             "title": "stop",
                             "description": "Time to end screensaver at (12h or 24h)",
-                            "default": "",
-                            "examples": [
-                                "22:30"
-                            ]
+                            "default": "07:00"
                         },
                         "data_updates": {
                             "$id": "#/properties/sbio/properties/screensaver/properties/data_updates",
                             "type": "boolean",
                             "title": "data_updates",
                             "description": "Update weather and NHL data while screen saver is active",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "default": false
                         },
                         "motionsensor": {
                             "$id": "#/properties/sbio/properties/screensaver/properties/motionsensor",
                             "type": "boolean",
                             "title": "motionsensor",
                             "description": "Use motion sensor to stop screen saver",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "default": false
                         },
                         "pin": {
                             "$id": "#/properties/sbio/properties/screensaver/properties/pin",
                             "type": "integer",
                             "title": "pin",
                             "description": "What gpio pin motion sensor is connected to",
-                            "default": 0,
-                            "examples": [
-                                24
-                            ]
+                            "default": 0
                         },
                         "delay": {
                             "$id": "#/properties/sbio/properties/screensaver/properties/delay",
                             "type": "integer",
                             "title": "delay",
                             "description": "How long in seconds before there is no motion to turn screen saver back on",
-                            "default": 30,
-                            "examples": [
-                                30
-                            ]
+                            "default": 30
                         }
                     }
                 },
@@ -1105,20 +844,6 @@
                     "title": "dimmer",
                     "description": "Automatic setting of the brightness of scoreboard (software or hardware based)",
                     "default": {},
-                    "examples": [
-                        {
-                            "enabled": true,
-                            "mode": "always",
-                            "frequency": 5,
-                            "light_level_lux": 10,
-                            "sunset_brightness": 5,
-                            "source": "software",
-                            "sunrise_brightness": 40,
-                            "daytime": "8:30AM",
-                            "nighttime": "5:30PM",
-                            "offset": 90
-                        }
-                    ],
                     "additionalProperties": true,
                     "required": [
                         "enabled",
@@ -1138,21 +863,14 @@
                             "type": "boolean",
                             "title": "enabled",
                             "description": "Use the dimmer functionality",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "default": false
                         },
                         "source": {
                             "$id": "#/properties/sbio/properties/dimmer/properties/source",
                             "type": "string",
                             "title": "source",
                             "description": "Hardware (adafruit TSL2591 light sensor) or software (based on your IP address)",
-                            "default": "",
-                            "examples": [
-                                "software",
-                                "hardware"
-                            ],
+                            "default": "software",
                             "enum": [
                                 "software",
                                 "hardware"
@@ -1163,20 +881,14 @@
                             "type": "integer",
                             "title": "frequency",
                             "description": "How often in minutes that the dimmer code checks to see if it should adjust the brightness",
-                            "default": 5,
-                            "examples": [
-                                5
-                            ]
+                            "default": 5
                         },
                         "light_level_lux": {
                             "$id": "#/properties/sbio/properties/dimmer/properties/light_level_lux",
                             "type": "integer",
                             "title": "light_level_lux",
                             "description": "If using a sensor, the level of light where the dimmer will change the brightness",
-                            "default": 10,
-                            "examples": [
-                                10
-                            ]
+                            "default": 10
                         },
                         "mode": {
                             "$id": "#/properties/sbio/properties/dimmer/properties/mode",
@@ -1184,9 +896,6 @@
                             "title": "mode",
                             "description": "Run the dimmer always or just on offday",
                             "default": "always",
-                            "examples": [
-                                "always"
-                            ],
                             "enum": [
                                 "always",
                                 "off_day"
@@ -1197,52 +906,35 @@
                             "type": "string",
                             "title": "daytime",
                             "description": "What time is day time (can be 12 or 24 hour time)",
-                            "default": "8:30 AM",
-                            "examples": [
-                                "8:30 AM",
-                                "08:30"
-                            ]
+                            "default": "08:30"
                         },
                         "nighttime": {
                             "$id": "#/properties/sbio/properties/dimmer/properties/nighttime",
                             "type": "string",
                             "title": "nighttime",
                             "description": "What time is night time (can be 12 or 24 hour time)",
-                            "default": "5:30 PM",
-                            "examples": [
-                                "5:30 PM",
-                                "17:30"
-                            ]
+                            "default": "17:30"
                         },
                         "offset": {
                             "$id": "#/properties/sbio/properties/dimmer/properties/offset",
                             "type": "integer",
                             "title": "offset",
                             "description": "Value of offset in minutes for sunrise and sunset for automatic sunrise/sunset from location only.  Can be positive or negative",
-                            "default": 0,
-                            "examples": [
-                                90
-                            ]
+                            "default": 0
                         },
                         "sunset_brightness": {
                             "$id": "#/properties/sbio/properties/dimmer/properties/sunset_brightness",
                             "type": "integer",
                             "title": "sunset_brightness",
                             "description": "Value of brightness you want when it's night",
-                            "default": 0,
-                            "examples": [
-                                5
-                            ]
+                            "default": 20
                         },
                         "sunrise_brightness": {
                             "$id": "#/properties/sbio/properties/dimmer/properties/sunrise_brightness",
                             "type": "integer",
                             "title": "sunrise_brightness",
                             "description": "Value of brightness you want when it's daytime",
-                            "default": 0,
-                            "examples": [
-                                40
-                            ]
+                            "default": 60
                         }
                     }
                 },
@@ -1252,21 +944,6 @@
                     "title": "pushbutton",
                     "description": "Settings for the pushbutton",
                     "default": {},
-                    "examples": [
-                        {
-                            "reboot_override_process": "",
-                            "reboot_duration": 2,
-                            "display_halt": true,
-                            "enabled": true,
-                            "state_triggered1": "weather",
-                            "bonnet": true,
-                            "pin": 25,
-                            "state_triggered1_process": "",
-                            "display_reboot": true,
-                            "poweroff_duration": 10,
-                            "poweroff_override_process": ""
-                        }
-                    ],
                     "additionalProperties": true,
                     "required": [
                         "enabled",
@@ -1287,111 +964,78 @@
                             "type": "boolean",
                             "title": "enabled",
                             "description": "Use the pushbutton code or not",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "default": false
                         },
                         "bonnet": {
                             "$id": "#/properties/sbio/properties/pushbutton/properties/bonnet",
                             "type": "boolean",
                             "title": "bonnet",
                             "description": "What type of adafruit rgb matrix interface is connected, hat or bonnet.  Defines what GIO pins are available.  True=bonnet false=HAT",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "default": false
                         },
                         "pin": {
                             "$id": "#/properties/sbio/properties/pushbutton/properties/pin",
                             "type": "integer",
                             "title": "pin",
                             "description": "The gpiozero number pin your button is connected to",
-                            "default": 25,
-                            "examples": [
-                                25
-                            ]
+                            "default": 25
                         },
                         "reboot_duration": {
                             "$id": "#/properties/sbio/properties/pushbutton/properties/reboot_duration",
                             "type": "integer",
                             "title": "reboot_duration",
                             "description": "Number of seconds the PushButton must be held to trigger a reboot. 2 is the minimum value",
-                            "default": 2,
-                            "examples": [
-                                2
-                            ]
+                            "default": 2
                         },
                         "reboot_override_process": {
                             "$id": "#/properties/sbio/properties/pushbutton/properties/reboot_override_process",
                             "type": "string",
                             "title": "reboot_override_process",
                             "description": "Process or script to use instead of the default /sbin/reboot command. Must have full path to script/process and no arguments for the process. If you need arguments, wrap in a script. If this is blank or the command/process does not exist, falls back to the default",
-                            "default": "",
-                            "examples": [
-                                ""
-                            ]
+                            "default": ""
                         },
                         "display_reboot": {
                             "$id": "#/properties/sbio/properties/pushbutton/properties/display_reboot",
                             "type": "boolean",
                             "title": "display_reboot",
                             "description": "Show the word REBOOT in green on scoreboard when reboot triggered",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "default": false
                         },
                         "poweroff_duration": {
                             "$id": "#/properties/sbio/properties/pushbutton/properties/poweroff_duration",
                             "type": "integer",
                             "title": "poweroff_duration",
                             "description": "Number of seconds the PushButton must be held to trigger a poweroff. Must be greater than reboot_duration. If reboot_duration is higher than poweroff_duration, the code will swap them",
-                            "default": 10,
-                            "examples": [
-                                10
-                            ]
+                            "default": 10
                         },
                         "poweroff_override_process": {
                             "$id": "#/properties/sbio/properties/pushbutton/properties/poweroff_override_process",
                             "type": "string",
                             "title": "poweroff_override_process",
                             "description": "Process or script to use instead of the default /sbin/poweroff command. Must have full path to script/process and no arguments for the process. If you need arguments, wrap in a script.. If this is blank or the command/process does not exist, falls back to the default",
-                            "default": "",
-                            "examples": [
-                                ""
-                            ]
+                            "default": ""
                         },
                         "display_halt": {
                             "$id": "#/properties/sbio/properties/pushbutton/properties/display_halt",
                             "type": "boolean",
                             "title": "display_halt",
                             "description": "Show the word ! HALT ! in red on scoreboard when poweroff triggered",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "default": false
                         },
                         "state_triggered1": {
                             "$id": "#/properties/sbio/properties/pushbutton/properties/state_triggered1",
                             "type": "string",
                             "title": "state_triggered1",
-                            "description": "The board you want displayed on button press. If this is blank falls back to the default board which is clock. Current boards available are scoreticker, standings, clock and weather",
+                            "description": "The board you want displayed on button press. If this is blank falls back to the default board which is clock. Current boards available are scoreticker, standings, clock, covid19, and weather",
                             "default": "clock",
-                            "examples": [
-                                "weather",
-                                "standings"
-                            ]
+                            "$ref": "#/definitions/boards_list"
                         },
                         "state_triggered1_process": {
                             "$id": "#/properties/sbio/properties/pushbutton/properties/state_triggered1_process",
                             "type": "string",
                             "title": "state_triggered1_process",
                             "description": "Process or script to use when a single press of the button happens to switch the board. Must have full path to script/process and no arguments for the process. If you need arguments, wrap in a script.",
-                            "default": "",
-                            "examples": [
-                                ""
-                            ]
+                            "default": ""
                         }
                     }
                 }


### PR DESCRIPTION
- Removed examples, moved to defaults where missing. Can easily access default objects from these fields.
- "teams" descriptive title => "Teams" (`teams` property name remains unchanged.)
- "team" items descriptive title => "Team"
- Updated patterns for screensaver.start/stop which would invalidate 12hr times (i.e. 04:00 **PM**) in previous configurations. Now validates both 00:00, and 12:00 AM times.