### PR TITLE
Update install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,13 +15,19 @@ sudo pip3 install -r requirements.txt
 git submodule update --init --recursive
 git config submodule.matrix.ignore all
 
-cd submodules/matrix || exit
 echo "$(tput setaf 4)Running rgbmatrix installation...$(tput setaf 9)"
 
-make build-python PYTHON="$(which python3)"
-sudo make install-python PYTHON="$(which python3)"
-cd bindings || exit 
-sudo pip3 install --force-reinstall -e python/
+# Recompile the cpp files to build library with newest cython.  See https://github.com/hzeller/rpi-rgb-led-matrix/issues/1298
+
+cd submodules/matrix/bindings/python || exit
+
+python3 -m pip install --no-cache-dir cython
+python3 -m cython -2 --cplus *.pyx
+
+cd ../../ || exit
+
+make build-python PYTHON="$(command -v python3)"
+sudo make install-python PYTHON="$(command -v python3)"
 
 cd ../../../ || exit
 


### PR DESCRIPTION
Add in recompiling of the cpp files by newest cython to allow for the matrix library to be built under Python 3.9 (which is installed with the newest raspberry pi OS)