### PR TITLE
Attr Key fix for missing SC champ. team id in data

### DIFF
--- a/src/boards/stanley_cup_champions.py
+++ b/src/boards/stanley_cup_champions.py
@@ -4,10 +4,10 @@ import debug
 
 class StanleyCupChampions:
     def __init__(self, data, matrix, sleepEvent):
-        debug.info("Stanley cup champions id: {}".format(data.ScChampions_id))
-        self.team_id = data.ScChampions_id
+        debug.info("Stanley cup champions id: {}".format(data.cup_winner_id))
+        self.team_id = data.cup_winner_id
         if self.team_id is None:
-            return
+            pass
         self.team_abbrev = data.teams_info[self.team_id].abbreviation
         self.data = data
         self.team_info = data.teams_info[self.team_id]

--- a/src/data/data.py
+++ b/src/data/data.py
@@ -180,7 +180,7 @@ class Data:
         self.refresh_playoff()
 
         # Stanley cup champions
-        self.ScChampions_id = self.check_stanley_cup_champion()
+        self.cup_winner_id = self.check_stanley_cup_champion()
 
 
     #
@@ -528,8 +528,7 @@ class Data:
             for x in range(len(self.current_round.series[0].matchupTeams)):
                 if self.current_round.series[0].matchupTeams[x].seriesRecord.wins >= 4:
                     return self.current_round.series[0].matchupTeams[x].team.id
-                else:
-                    return False
+                return
 
     def series_by_conference():
         """

--- a/src/renderer/main.py
+++ b/src/renderer/main.py
@@ -167,7 +167,7 @@ class MainRenderer:
                 self.check_new_goals()
                 if self.data.isPlayoff and self.data.stanleycup_round:
                     self.check_stanley_cup_champion()
-                    if self.data.ScChampions_id:
+                    if self.data.cup_winner_id:
                         StanleyCupChampions(self.data, self.matrix, self.sleepEvent).render()
 
                 self.__render_postgame(sbrenderer)
@@ -181,7 +181,7 @@ class MainRenderer:
                 self.check_new_goals()
                 if self.data.isPlayoff and self.data.stanleycup_round:
                     self.check_stanley_cup_champion()
-                    if self.data.ScChampions_id:
+                    if self.data.cup_winner_id:
                         StanleyCupChampions(self.data, self.matrix, self.sleepEvent).render()
                 self.__render_postgame(sbrenderer)
 
@@ -407,5 +407,5 @@ class MainRenderer:
         self.matrix.graphics.DrawLine(self.matrix.matrix, (self.matrix.width * .5) - 9, self.matrix.height - 1, (self.matrix.width * .5) + 9, self.matrix.height - 1, color)
 
     def test_stanley_cup_champion(self, team_id):
-        self.data.ScChampions_id = team_id
+        self.data.cup_winner_id = team_id
         StanleyCupChampions(self.data, self.matrix, self.sleepEvent).render()


### PR DESCRIPTION
- Simply pass instead of returning key error when no SC team id is found.
- Renamed `ScChampions_id` to `cup_winner_id` where used.