### PR TITLE
Tweaks to mqtt, EC thread not stopping the Board on start and Colorful logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ python-tsl2591==0.2.0
 questionary>=1.5.2
 regex>=2020.4.4
 RPi.GPIO==0.7.0
-APScheduler>=3.6.3
+APScheduler==3.9.1
 lastversion>=1.1.6
 nameparser==1.0.6
 pillow==8.3.2
@@ -19,3 +19,4 @@ dbus-python
 iso6709
 #RGBMatrixEmulator
 paho-mqtt
+rich

--- a/src/debug.py
+++ b/src/debug.py
@@ -3,6 +3,7 @@ import data
 import time
 import sys
 import logging
+from rich.logging import RichHandler
 
 debug_enabled = False
 
@@ -35,7 +36,7 @@ def set_debug_status(config,logcolor=False,loglevel='INFO'):
 		if colorAvail:
 			coloredlogs.install(level='DEBUG',fmt='%(asctime)s %(name)s %(levelname)s %(message)s',stream=sys.stdout)
 		else:
-			logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s', level=logging.DEBUG, datefmt='%y-%m-%d %H:%M:%S')
+			logging.basicConfig(format='%(message)s', level=logging.DEBUG, datefmt='%y-%m-%d %H:%M:%S',handlers=[RichHandler(omit_repeated_times=False,tracebacks_show_locals=True,rich_tracebacks=True)])
 
 	else:
 		if colorAvail:
@@ -44,7 +45,8 @@ def set_debug_status(config,logcolor=False,loglevel='INFO'):
 			handler = logging.StreamHandler(sys.stdout)
 			formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
 			handler.setFormatter(formatter)
-			logger.addHandler(handler)
+			#logger.addHandler(handler)
+			logger.addHandler(RichHandler(show_path=False,omit_repeated_times=False,tracebacks_show_locals=True,rich_tracebacks=True))
 			logger.setLevel(loglevel)
 
 
@@ -56,6 +58,12 @@ def log(text):
 	if debug_enabled:
 		#__debugprint("DEBUG ({}): {}".format(__timestamp(), text))
 		logger.debug(text)
+
+def critical(text):
+	logger.critical(text,stack_info=True)
+
+def exception(text,e):
+  logger.exception(text,exc_info=e)
 
 def warning(text):
   #__debugprint("WARNING ({}): {}".format(__timestamp(), text))


### PR DESCRIPTION
Made paho-mqtt library conditional.  Removed the try/except for when …EC couldn't connect on start and it would stop the board.  Updated the logging to use the rich library for better colors and stack traces.  Updated requirements.txt to add new libraries and pin apscheduler to 3.9.1.  Also forced the scheduler to use your local timezone to remove an error thrown by apscheduler and the tzlocal libraries.