### PR TITLE
seasoncountdown now will use the next season info from the NHL api

### DIFF
--- a/src/boards/seasoncountdown.py
+++ b/src/boards/seasoncountdown.py
@@ -1,7 +1,7 @@
 from rgbmatrix import graphics
 from PIL import ImageFont, Image
 from utils import center_text
-import datetime
+from datetime import datetime, date
 import debug
 from time import sleep
 from utils import get_file
@@ -19,9 +19,17 @@ class SeasonCountdown:
         self.font = data.config.layout.font
         self.font.large = data.config.layout.font_large_2
         # Current season seems to not update until pre-season start so I will have to modify the Status and the nhl_api to get the coming season.
-        self.season_start = datetime.date(2021,10,12)
-        self.days_until_season = (self.season_start - datetime.date.today()).days
+        #self.season_start = datetime.date(2021,10,12)
+        self.season_start = datetime.strptime(self.data.status.next_season_start(), '%Y-%m-%d').date()
+        self.days_until_season = (self.season_start - date.today()).days
         self.scroll_pos = self.matrix.width
+        
+        # Set up season text
+        current_year = date.today().year
+        next_year = current_year + 1
+    
+        self.nextseason="{0}-{1}".format(current_year,next_year)
+        self.nextseason_short="NHL {0}-{1}".format(str(current_year)[-2:],str(next_year)[-2:])
 
     def draw(self):
         
@@ -47,7 +55,7 @@ class SeasonCountdown:
 
         self.matrix.draw_image((15,0), nhl_logo)
         
-        debug.info("2021-2022 season has begun")
+        debug.info("{0} season has begun".format(self.nextseason))
 
         self.matrix.render()
         self.sleepEvent.wait(0.5)
@@ -56,7 +64,7 @@ class SeasonCountdown:
         #draw bottom text        
         self.matrix.draw_text(
             (14,25), 
-            "2021-2022", 
+            self.nextseason, 
             font=self.font,
             fill=(0,0,0),
             backgroundColor=(155,155,155)
@@ -74,7 +82,7 @@ class SeasonCountdown:
         self.matrix.draw_image((34,0), nhl_logo)
         self.matrix.draw_image((-5,0), black_gradiant)
         
-        debug.info("Counting down to NHL 21-22")
+        debug.info("Counting down to {0}".format(self.nextseason_short))
 
         self.matrix.render()
         self.sleepEvent.wait(0.5)
@@ -104,7 +112,7 @@ class SeasonCountdown:
         #draw bottom text        
         self.matrix.draw_text(
             (1,25), 
-            "NHL 21-22", 
+            self.nextseason_short, 
             font=self.font,
             fill=(0,0,0),
             backgroundColor=(155,155,155)

--- a/src/data/data.py
+++ b/src/data/data.py
@@ -224,11 +224,14 @@ class Data:
             # Reset flag
             self.all_pref_games_final = False
             
-            self.refresh_daily()
-            
+            #Don't think this is needed to be called a second time
+           #self.refresh_daily()           
+            self.status.refresh_next_season()
+           
             return True
         else:
             debug.info("It is not a new day")
+                        
             return False
 
     #
@@ -579,3 +582,6 @@ class Data:
 
         # Fetch the playoff data
         self.refresh_playoff()
+        
+ 
+        

--- a/src/data/status.py
+++ b/src/data/status.py
@@ -1,11 +1,12 @@
-from datetime import datetime
-from nhl_api import game_status_info, current_season_info
+from datetime import datetime, date
+from nhl_api import game_status_info, current_season_info, next_season_info
 import debug
 
 class Status:
     def __init__(self):
         game_status = game_status_info()
         self.season_info = current_season_info()['seasons'][0]
+        #self.next_season_info = next_season_info()['seasons'][0]
         self.season_id = self.season_info["seasonId"]
         self.Preview = []
         self.Live = []
@@ -26,7 +27,17 @@ class Status:
                     self.GameOver.append(status['detailedState'])
                 else:
                     self.Final.append(status['detailedState'])
-
+        
+        # # Make sure that the next_season_info is not an empty list, if it is, make next_season = to current season
+        
+        # if not self.next_season_info:
+        #     debug.info("Next season info unavailable, defaulting to Oct 1 of current year as start of new season")
+        #     self.next_season_info = self.season_info
+        #     # Arbitrarily set the regularSeasonStartDate to Oct 1 of current year
+        #     self.next_season_info['regularSeasonStartDate'] = "{0}-10-01".format(date.today().year)
+        
+        self.refresh_next_season()
+        
 
     def is_scheduled(self, status):
         return status in self.Preview
@@ -62,5 +73,21 @@ class Status:
         except TypeError:
             debug.error('The Argument provided for status.is_playoff is missing or not right.')
             return False
+     
+    def refresh_next_season(self):
+        debug.info("Updating next season info")
+        self.season_info = current_season_info()['seasons'][0]
+        self.next_season_info = next_season_info()['seasons'][0]
+        # Make sure that the next_season_info is not an empty list, if it is, make next_season = to current season
+        
+        if not self.next_season_info:
+            debug.info("Next season info unavailable, defaulting to Oct 1 of current year as start of new season")
+            self.next_season_info = self.season_info
+            # Arbitrarily set the regularSeasonStartDate to Oct 1 of current year
+            self.next_season_info['regularSeasonStartDate'] = "{0}-10-01".format(date.today().year)
+            
+           
+    def next_season_start(self):
+        return self.next_season_info['regularSeasonStartDate']
 
     

--- a/src/nhl_api/__init__.py
+++ b/src/nhl_api/__init__.py
@@ -39,6 +39,8 @@ def game_status_info():
 def current_season_info():
     return nhl_api.info.current_season()
 
+def next_season_info():
+    return nhl_api.info.next_season()
 
 def standings():
     try:

--- a/src/nhl_api/data.py
+++ b/src/nhl_api/data.py
@@ -1,6 +1,7 @@
 import json
 import requests
 import debug
+from datetime import date
 
 """
     TODO:
@@ -15,6 +16,7 @@ PLAYER_URL = '{0}people/{1}'
 OVERVIEW_URL = BASE_URL + 'game/{0}/feed/live?site=en_nhl'
 STATUS_URL = BASE_URL + 'gameStatus'
 CURRENT_SEASON_URL = BASE_URL + 'seasons/current'
+NEXT_SEASON_URL = BASE_URL + 'seasons/{0}'
 STANDINGS_URL = BASE_URL + 'standings'
 STANDINGS_WILD_CARD = STANDINGS_URL + '/wildCardWithLeaders'
 PLAYOFF_URL = BASE_URL + "tournaments/playoffs?expand=round.series,schedule.game.seriesSummary&season={}"
@@ -66,6 +68,20 @@ def get_game_status():
 def get_current_season():
     try:
         data = requests.get(CURRENT_SEASON_URL, timeout=REQUEST_TIMEOUT)
+        return data
+    except requests.exceptions.RequestException as e:
+        raise ValueError(e)
+    
+def get_next_season():
+    # Create the next seasonID from the current year and curent year +1 eg: 20232024 is seasonID for 2023-2024 season
+    # This will return an empty set for seasons data if the seasonID has nothing, a 200 response will always occur
+    current_year = date.today().year
+    next_year = current_year + 1
+    
+    nextseasonID="{0}{1}".format(current_year,next_year)
+    
+    try:
+        data = requests.get(NEXT_SEASON_URL.format(nextseasonID), timeout=REQUEST_TIMEOUT)
         return data
     except requests.exceptions.RequestException as e:
         raise ValueError(e)

--- a/src/nhl_api/info.py
+++ b/src/nhl_api/info.py
@@ -119,6 +119,10 @@ def current_season():
     data = nhl_api.data.get_current_season().json()
     return data
 
+def next_season():
+    data = nhl_api.data.get_next_season().json()
+    return data
+
 
 def playoff_info(season):
     data = nhl_api.data.get_playoff_data(season)


### PR DESCRIPTION
The seasoncountdown board will use NHL API to determine when next season starts.  If the next season is not returned back from the API, the current season year is used and an arbitrary start date of October 1 is used.  The next season is checked daily.