### PR TITLE
Fix scoreboard stuck in off day

### DIFF
--- a/src/data/data.py
+++ b/src/data/data.py
@@ -285,7 +285,7 @@ class Data:
         attempts_remaining = 5
         while attempts_remaining > 0:
             try:
-                data = nhl_api.data.get_score_details("{}-{}-{}".format(self.year, self.month, self.day))
+                data = nhl_api.data.get_score_details("{}-{}-{}".format(str(self.year), str(self.month).zfill(2), str(self.day).zfill(2)))
                 if not data:
                     self.games = []
                     self.pref_games = []


### PR DESCRIPTION
Updates get_score_details call in data.py to have 2 character month and date. This fixes the issue that cause the scoreboard to be stuck in off day mode.